### PR TITLE
Added "Access-Control-Allow-Headers : *" header in server responses

### DIFF
--- a/src/it/ismb/pert/dal/web/apis/rest/resources/BaseServerResource.java
+++ b/src/it/ismb/pert/dal/web/apis/rest/resources/BaseServerResource.java
@@ -14,6 +14,7 @@ public class BaseServerResource extends ServerResource{
 		    getResponse().getAttributes().put("org.restlet.http.headers", responseHeaders);
 		}
 		responseHeaders.add(new Header("Access-Control-Allow-Origin", "*"));
+		responseHeaders.add(new Header("Access-Control-Allow-Headers", "*"));
 	}
 
 }


### PR DESCRIPTION
Added "Access-Control-Allow-Headers : *" header in server responses in order to let different origins invoke APIs with their headers without errors.
